### PR TITLE
Fix tailwind PostCSS plugin

### DIFF
--- a/packages/tailwind-config/postcss.config.js
+++ b/packages/tailwind-config/postcss.config.js
@@ -1,6 +1,6 @@
 // Optional PostCSS configuration for applications that need it
 export const postcssConfig = {
   plugins: {
-    "@tailwindcss/postcss": {},
+    tailwindcss: {},
   },
 };


### PR DESCRIPTION
## Summary
- fix invalid plugin name in postcss.config.js

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488048a37483218c4c60517f37ed23